### PR TITLE
タイトル管理とドラッグ&ドロップ

### DIFF
--- a/posse-3rd-laravel-study/app/Http/Controllers/AdmintitleController.php
+++ b/posse-3rd-laravel-study/app/Http/Controllers/AdmintitleController.php
@@ -7,6 +7,11 @@ use Illuminate\Http\Request;
 
 class AdmintitleController extends Controller
 {
+  // 未ログインの場合は、ログイン画面に遷移させる
+  public function __construct(){
+    $this->middleware('auth');
+  }
+
   public function index()
   {
     $prefectures = Prefecture::all();

--- a/posse-3rd-laravel-study/public/js/edit_title.js
+++ b/posse-3rd-laravel-study/public/js/edit_title.js
@@ -1,0 +1,19 @@
+// Sortable.jsを利用したドラッグ&ドロップ
+window.onload = function () {
+  let prefectureItems = document.getElementById('prefectureItems');
+  Sortable.create(prefectureItems, {
+    animation: 150,
+    //   localStorageに保存
+    group: "save",
+    store: {
+      get: function (sortable) {
+        var order = localStorage.getItem(sortable.options.group.name);
+        return order ? order.split('|') : [];
+      },
+      set: function (sortable) {
+        var order = sortable.toArray();
+        localStorage.setItem(sortable.options.group.name, order.join('|'));
+      }
+    }
+  });
+}

--- a/posse-3rd-laravel-study/resources/views/admin/edit_title.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/edit_title.blade.php
@@ -21,9 +21,9 @@
                         <th>削除</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody id="prefectureItems">
                     @foreach ($prefectures as $prefecture)
-                        <tr>
+                        <tr data-id="{{ $prefecture->id }}">
                             <td>
                                 {{-- <a href="edit_title/{{ $prefecture->id }}">{{ $prefecture->name }}の難読地名クイズ</a> --}}
                                 <div><span class="font-weight-bold">{{ $prefecture->name }}</span>の難読地名クイズ</div>
@@ -45,3 +45,8 @@
         </section>
     </div>
 @endsection
+
+{{-- 特定のjsの読み込み --}}
+@push('scripts')
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+@endpush

--- a/posse-3rd-laravel-study/resources/views/home.blade.php
+++ b/posse-3rd-laravel-study/resources/views/home.blade.php
@@ -1,25 +1,27 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">Dashboard</div>
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
-                        </div>
-                    @endif
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-header">各メンテナンス画面を選択</div>
+                    <div class="card-body">
+                        @if (session('status'))
+                            <div class="alert alert-success" role="alert">
+                                {{ session('status') }}
+                            </div>
+                        @endif
 
-                    You are logged in!
-                    <a href={{ route('edit_title.index') }} class=''>
-                       タイトル管理へ
-                    </a>
+                        <div class="mt-3">
+                            <a href={{ route('edit_title.index') }} class='h4'>
+                                1. タイトル管理へ
+                            </a>
+                        </div>
+
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/posse-3rd-laravel-study/resources/views/layouts/app.blade.php
+++ b/posse-3rd-laravel-study/resources/views/layouts/app.blade.php
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -9,10 +10,16 @@
 
     <title>Quizy｜{{ config('app.name', 'Laravel') }}</title>
 
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.0/jquery-ui.js"></script>
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
     {{-- クイズ処理用のjs --}}
-    <script src="{{asset('js/quizy.js')}}"></script>
+    <script src="{{ asset('js/quizy.js') }}"></script>
+    {{-- タイトル編集js --}}
+    <script src="{{ asset('js/edit_title.js') }}"></script>
+    {{-- edit_titleブレード参照 --}}
+    @stack('scripts')
 
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
@@ -22,6 +29,7 @@
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
 </head>
+
 <body>
     <div id="app">
         <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
@@ -29,7 +37,9 @@
                 <a class="navbar-brand" href="{{ url('/') }}">
                     {{ config('app.name', 'Laravel') }}
                 </a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+                <button class="navbar-toggler" type="button" data-toggle="collapse"
+                    data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
+                    aria-label="{{ __('Toggle navigation') }}">
                     <span class="navbar-toggler-icon"></span>
                 </button>
 
@@ -53,18 +63,20 @@
                             @endif
                         @else
                             <li class="nav-item dropdown">
-                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button"
+                                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                     {{ Auth::user()->name }} <span class="caret"></span>
                                 </a>
 
                                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                                     <a class="dropdown-item" href="{{ route('logout') }}"
-                                       onclick="event.preventDefault();
+                                        onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">
                                         {{ __('Logout') }}
                                     </a>
 
-                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                                    <form id="logout-form" action="{{ route('logout') }}" method="POST"
+                                        style="display: none;">
                                         @csrf
                                     </form>
                                 </div>
@@ -80,4 +92,5 @@
         </main>
     </div>
 </body>
+
 </html>

--- a/study_memo/laravel.txt
+++ b/study_memo/laravel.txt
@@ -20,3 +20,89 @@ Userモデルクラス・・Illuminate\Database\Eloquent\ModelのModelクラス�
 User::find(1);・・・・(new User())->find(1);と等価（findはクエリビルダのメソッド）
 
 Eloquentではtableメソッドを記述せずともクエリビルダを利用することができる
+
+
+
+**ドラッグアンドドロップ情報をDB保存の場合はこちらを使うか
+// jQuery(function ($) {
+
+//   let lists = $('ul.list-group li')
+//   lists.on('dragstart', onDragStart)
+//   lists.on('dragover', onDragOver)
+//   lists.on('dragleave', onDragLeave)
+//   lists.on('drop', onDrop)
+
+//   $('form').submit(updateOrder)
+
+//   function onDragStart(e) {
+//     e.originalEvent.dataTransfer.setData('text', $(this).data('id'))
+//   }
+
+//   function onDragOver(e) {
+//     e.preventDefault()
+
+//     if ((e.offsetY) < ($(this).innerHeight() / 2)) {
+//       //マウスカーソルの位置が要素の半分より上
+//       $(this).css({
+//         'border-top': '2px solid blue',
+//         'border-bottom': '',
+//       })
+//     } else {
+//       //マウスカーソルの位置が要素の半分より下
+//       $(this).css({
+//         'border-top': '',
+//         'border-bottom': '2px solid blue',
+//       })
+//     }
+//   }
+
+//   function onDragLeave(e) {
+//     $(this).css({
+//       'border-top': '',
+//       'border-bottom': '',
+//     })
+//   }
+
+//   function onDrop(e) {
+//     e.preventDefault()
+//     let id = e.originalEvent.dataTransfer.getData('text')
+
+//     if ((e.offsetY) < ($(this).innerHeight() / 2)) {
+//       $('li[data-id=\'' + id + '\']').insertBefore(this)
+//     } else {
+//       $('li[data-id=\'' + id + '\']').insertAfter(this)
+//     }
+//     $(this).css({
+//       'border-top': '',
+//       'border-bottom': '',
+//     })
+
+//   }
+
+//   function updateOrder() {
+//     let listOrder = []
+//     $('ul.list-group li').each(function () {
+//       listOrder.push($(this).data('id'))
+//     })
+
+//     $('#list_order').val(listOrder.join(','))
+
+//     console.log($('#list_order').val())
+//   }
+
+// })
+
+**html
+
+<form>
+        <ul class="list-group">
+            <li class="list-group-item list-group-item-action" data-id="1" draggable="true">項目１</li>
+            <li class="list-group-item list-group-item-action" data-id="2" draggable="true">項目２</li>
+            <li class="list-group-item list-group-item-action" data-id="3" draggable="true">項目３</li>
+            <li class="list-group-item list-group-item-action" data-id="4" draggable="true">項目４</li>
+            <li class="list-group-item list-group-item-action" data-id="5" draggable="true">項目５</li>
+        </ul>
+
+        <input type="hidden" name="list_order" id="list_order">
+        <button type="submit" class="btn btn-primary">送信</button>
+    </form>


### PR DESCRIPTION
# 今週(41週)の課題
- [x] 登録済みの問題タイトルが一覧で表示されていますか？
- [x] 問題タイトルを追加可能ですか？
- [x] 登録済みの問題タイトルを変更可能ですか？
- [x] 登録済みの問題タイトルを削除可能ですか？
- [x] 登録済みの問題タイトルの順序を変更可能ですか？
- [x] 問題タイトルをクリックすると、設問のメンテナンス画面に遷移しますか？

## 注意点やレビュワーに伝えたいこと(あれば)

①管理画面へのアクセスにおいて、未ログインの際はログイン画面に飛ばすようmiddeware挟みました。
②ドラッグ&ドロップは、jsのライブラリであるSortablejsを使用、ドラッグ&ドロップがlocalstorageに即自的に保存されます。※cookieデータ削除でlocalstorage情報が削除されてしまうデメリットはありますが、今回のドラッグ&ドロップはリセットされてもさほど大きな問題ではないため良いかなと考えています。

## 課題が終わっている証跡(スクショ)
![image](https://user-images.githubusercontent.com/86698414/178184296-4a33fc00-a6c4-4953-8f3b-9b32dc1d7ba5.png)
