### PR TITLE
設問画像の追加、編集、削除ページの実装

### DIFF
--- a/posse-3rd-laravel-study/app/Choice.php
+++ b/posse-3rd-laravel-study/app/Choice.php
@@ -6,5 +6,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class Choice extends Model
 {
-    
+    protected $fillable = [
+        'choice',
+        'valid',
+        'question_id',
+    ];
 }

--- a/posse-3rd-laravel-study/app/Http/Controllers/AdminchoiceController.php
+++ b/posse-3rd-laravel-study/app/Http/Controllers/AdminchoiceController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+// モデルの読み込み
+use App\Question;
+use App\Choice;
+
+use Illuminate\Http\Request;
+
+class AdminchoiceController extends Controller
+{
+    //
+    public function index($question_id)
+  {
+    $choices = Choice::where('question_id', $question_id)->get();
+    $image = Question::where('id', $question_id)->first()->image;
+    return view('admin/edit_choice', compact('choices', 'question_id', 'image'));
+  }
+
+  public function store(Request $request, $question_id)
+  {
+    $form = $request->all();
+    unset($form['_token']);
+    Choice::create($form);
+    return redirect()->route('edit_choice.index', ['question_id' => $question_id]);
+  }
+
+  public function edit($id)
+  {
+    $choice = Choice::find($id);
+    return view('/admin/each_edit_choice', compact('choice'));
+  }
+
+  public function update(Request $request, $id)
+  {
+    $choice = Choice::find($id);
+    //値を代入
+    $choice->choice = $request->choice;
+    //保存（更新）
+    $choice->save();
+    //リダイレクト
+    return redirect()->route('edit_choice.index', ['question_id' => $choice->question_id]);
+  }
+
+  public function destroy($id)
+  {
+    //削除対象レコードを検索
+    $choice = Choice::find($id);
+    $choice->delete();
+    return redirect()->route('edit_choice.index', ['question_id' => $choice->question_id]);
+  }
+
+}

--- a/posse-3rd-laravel-study/app/Http/Controllers/AdminquestionController.php
+++ b/posse-3rd-laravel-study/app/Http/Controllers/AdminquestionController.php
@@ -21,6 +21,7 @@ class AdminquestionController extends Controller
   public function store(Request $request)
   {
     $question = new Question;
+    // ↓$requestでinputタグのnameをわざわざ送らなくても、questionインスタンスからprefecture_idにアクセスできるか
     $prefecture_id = $request->prefecture_id;
 
     // 画像データ保存:storage/app/public

--- a/posse-3rd-laravel-study/app/Http/Controllers/AdminquestionController.php
+++ b/posse-3rd-laravel-study/app/Http/Controllers/AdminquestionController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers;
+// モデルの読み込み
+use App\Prefecture;
+use App\Question;
+use Illuminate\Http\Request;
+// ファサード
+use Illuminate\Support\Facades\Storage;
+
+class AdminquestionController extends Controller
+{
+  //
+  public function index($prefecture_id)
+  {
+    // findはプライマリーキーの検索なため、外部キー検索はwhereを用いた
+    $questions = Question::where('prefecture_id', $prefecture_id)->get();
+    return view('admin/edit_question', compact('questions', 'prefecture_id'));
+  }
+
+  public function store(Request $request)
+  {
+    $question = new Question;
+    $prefecture_id = $request->prefecture_id;
+
+    // 画像データ保存:storage/app/public
+    // 画像データ読込:public/storage
+
+    // name属性が'question'のinputタグをファイル形式に、画像をstorage/app/public/imagesに保存
+    $image_path = $request->file('question')->store('public/temp');
+    str_replace('public/', 'storage/', $image_path); //追加
+
+    // 画像のファイル名をDB保存・・上記処理にて保存した画像に名前を付け、questionテーブルのimageカラムに格納
+    $question->image = basename($image_path);
+    $question->prefecture_id = $request->prefecture_id;
+
+    $question->save();
+
+    return redirect()->route('edit_question.index', ['id' => $prefecture_id]);
+  }
+
+  public function edit($id)
+  {
+    //レコードを検索
+    $question = Question::find($id);
+    return view('/admin/each_edit_question', compact('question'));
+  }
+
+  public function update(Request $request, $id)
+  {
+    $question = Question::find($id);
+    // 画像ファイルインスタンス取得
+    $image = $request->file('question');
+    // 現在の画像へのパスをセット
+    $image_path = $question->image;
+    if (isset($image)) {
+      // 現在の画像ファイルの削除
+      Storage::disk('public')->delete($image_path);
+      // 選択された画像ファイルを保存してパスをセット
+      $image_path = $image->store('public/temp');
+      // ファイル名は$temp_pathから"public/temp/"を除いたもの
+      $filename = str_replace('public/temp/', '', $image_path);
+      // データベースを更新
+      $question->update([
+        'image' => $filename,
+      ]);
+    }
+
+    $prefecture_id = $question->prefecture_id;
+
+    return redirect()->route('edit_question.index', ['id' => $prefecture_id]);
+  }
+
+  public function destroy(Request $request, $id)
+  {
+    //削除対象レコードを検索
+    $question = Question::find($id);
+    $prefecture_id = $request->prefecture_id;
+
+    $question->delete();
+    return redirect()->route('edit_question.index', ['id' => $prefecture_id]);
+  }
+}

--- a/posse-3rd-laravel-study/resources/views/admin/each_edit_choice.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/each_edit_choice.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+@section('content')
+    <h1>選択肢編集</h1>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <a href="{{ route('edit_choice.index', ['question_id' => $choice->question_id]) }}" class="btn btn-primary" style="margin:20px;">一覧に戻る</a>
+        </div>
+    </div>
+    <!-- form -->
+    <form method="post" action="{{ route("edit_choice.update", ['id' => $choice->id]) }}">
+        @csrf
+        <div class="form-group">
+            <label>名前</label>
+            <input type="text" placeholder="選択肢" name="choice" value="{{ $choice->choice }}">
+        </div>
+        <input type="submit" value="更新" class="btn btn-primary">
+    </form>
+@endsection

--- a/posse-3rd-laravel-study/resources/views/admin/each_edit_question.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/each_edit_question.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+@section('content')
+    <h1>設問の編集</h1>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <a href="{{ route('edit_question.index', ['id' => $question->prefecture_id]) }}" class="btn btn-primary" style="margin:20px;">一覧に戻る</a>
+        </div>
+    </div>
+
+    <form action={{ route("edit_question.update", ['id' => $question->id]) }} method="POST" enctype='multipart/form-data'>
+        @csrf
+        <img src="{{ asset('storage/temp/' . $question->image) }}" alt="" width="15%">
+        <label>設問</label>
+        <input type="file" name="question">
+        <input type="hidden" name="prefecture_id" value="{{ $question->prefecture_id }}">
+        <input type="submit" value="更新" class="btn btn-primary">
+    </form>
+@endsection

--- a/posse-3rd-laravel-study/resources/views/admin/edit_choice.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/edit_choice.blade.php
@@ -1,0 +1,65 @@
+@extends('layouts.app')
+@section('content')
+    <div class="mx-auto text-center">
+        <img src="{{ asset('storage/temp/' . $image) }}" alt="" width="25%">
+        {{-- 新規登録 --}}
+        <section class="mb-3">
+            <h2>新規登録</h2>
+            {{-- 正解の登録 --}}
+            <form action="{{ route("edit_choice.store", ['question_id' => $question_id]) }}" method="POST">
+                @csrf
+                <input type="text" placeholder="正解の選択肢" name="choice" value="{{ old('name') }}">
+                <input type="hidden" name="valid" value="1">
+                <input type="hidden" name="question_id" value="{{ $question_id }}">
+                <input type="submit" value="登録" class="btn btn-success font-weight-bold">
+            </form>
+            {{-- 不正解の登録 --}}
+            <form action="{{ route("edit_choice.store", ['question_id' => $question_id]) }}" method="POST" class="mt-2">
+                @csrf
+                <input type="text" placeholder="不正解の選択肢" name="choice" value="{{ old('name') }}">
+                <input type="hidden" name="valid" value="0">
+                <input type="hidden" name="question_id" value="{{ $question_id }}">
+                <input type="submit" value="登録" class="btn btn-secondary text-light font-weight-bold">
+            </form>
+        </section>
+        {{-- 編集 --}}
+        <section class="d-inline-block w-50">
+            <h2>設問の選択肢</h2>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>タイトル</th>
+                        <th>編集</th>
+                        <th>削除</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($choices as $choice)
+                        <tr>
+                            <td>
+                                <div>
+                                    <span class=
+                                    "font-weight-bold
+                                    @if($choice->valid == 1)
+                                    text-primary
+                                    @endif
+                                    ">{{ $choice->choice }}</span>
+                                </div>
+                            </td>
+                            <td>
+                                <a href="{{ route('edit_choice.edit', $choice->id) }}" class="btn btn-sm btn-primary">編集</a>
+                            </td>
+                            <td>
+                                <form action="{{ route('edit_choice.destroy', $choice->id) }}" method="POST">
+                                    @csrf
+                                    <input type="submit" class="btn btn-sm btn-danger"
+                                        onClick="return confirm('この選択肢を削除しますか？')" value="削除">
+                                </form>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </section>
+    </div>
+@endsection

--- a/posse-3rd-laravel-study/resources/views/admin/edit_question.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/edit_question.blade.php
@@ -29,7 +29,9 @@
                             <td>
                                 <div>
                                     {{-- <img src="/images/{{ $question->image }}" alt=""> --}}
-                                    <img src="{{ asset('storage/temp/' . $question->image) }}" alt="" width="15%">
+                                    <a href="{{ route("edit_choice.index", ['question_id' =>$question->id]) }}">
+                                        <img src="{{ asset('storage/temp/' . $question->image) }}" alt="" width="15%">
+                                    </a>
                                 </div>
                             </td>
                             <td>

--- a/posse-3rd-laravel-study/resources/views/admin/edit_question.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/edit_question.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+@section('content')
+    <div class="mx-auto text-center">
+        {{-- 新規登録 --}}
+        <section class="mb-3">
+            <h2>新規登録</h2>
+            {{-- この下の$prefectre_id必要なのか後で確認 --}}
+            <form action={{ route("edit_question.store", ['id' => $prefecture_id]) }} method="POST" enctype='multipart/form-data'>
+                @csrf
+                <input type="file" name="question" />
+                <input type="hidden" name="prefecture_id" value="{{ $prefecture_id }}">
+                <input type="submit" value="登録" class="btn btn-success">
+            </form>
+        </section>
+        {{-- 編集 --}}
+        <section class="d-inline-block w-60">
+            <h2>登録済みの設問</h2>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>タイトル</th>
+                        <th>編集</th>
+                        <th>削除</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($questions as $question)
+                        <tr class="">
+                            <td>
+                                <div>
+                                    {{-- <img src="/images/{{ $question->image }}" alt=""> --}}
+                                    <img src="{{ asset('storage/temp/' . $question->image) }}" alt="" width="15%">
+                                </div>
+                            </td>
+                            <td>
+                                <a href="{{ route('edit_question.edit', $question->id) }}" class="mt-2 p-3 btn btn-sm btn-primary">編集</a>
+                            </td>
+                            <td>
+                                <form action={{ route('edit_question.destroy', $question->id) }} method="POST">
+                                    @csrf
+                                    <input type="hidden" name="prefecture_id" value="{{ $prefecture_id }}">
+                                    <input type="submit" class="mt-2 p-3 btn btn-sm btn-danger"
+                                        onClick="return confirm('この設問を削除しますか？')" value="削除">
+                                </form>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </section>
+    </div>
+@endsection

--- a/posse-3rd-laravel-study/resources/views/admin/edit_title.blade.php
+++ b/posse-3rd-laravel-study/resources/views/admin/edit_title.blade.php
@@ -25,8 +25,9 @@
                     @foreach ($prefectures as $prefecture)
                         <tr data-id="{{ $prefecture->id }}">
                             <td>
-                                {{-- <a href="edit_title/{{ $prefecture->id }}">{{ $prefecture->name }}の難読地名クイズ</a> --}}
-                                <div><span class="font-weight-bold">{{ $prefecture->name }}</span>の難読地名クイズ</div>
+                                <div>
+                                    <a href="edit_question/{{ $prefecture->id }}"><span class="font-weight-bold">{{ $prefecture->name }}</span>の難読地名クイズ</a>
+                                </div>
                             </td>
                             <td>
                                 <a href="edit_title/edit/{{ $prefecture->id }}" class="btn btn-sm btn-primary">編集</a>
@@ -48,5 +49,7 @@
 
 {{-- 特定のjsの読み込み --}}
 @push('scripts')
+    {{-- タイトル編集js --}}
+    <script src="{{ asset('js/edit_title.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
 @endpush

--- a/posse-3rd-laravel-study/resources/views/layouts/app.blade.php
+++ b/posse-3rd-laravel-study/resources/views/layouts/app.blade.php
@@ -16,8 +16,6 @@
     <script src="{{ asset('js/app.js') }}" defer></script>
     {{-- クイズ処理用のjs --}}
     <script src="{{ asset('js/quizy.js') }}"></script>
-    {{-- タイトル編集js --}}
-    <script src="{{ asset('js/edit_title.js') }}"></script>
     {{-- edit_titleブレード参照 --}}
     @stack('scripts')
 

--- a/posse-3rd-laravel-study/resources/views/quizy.blade.php
+++ b/posse-3rd-laravel-study/resources/views/quizy.blade.php
@@ -6,7 +6,8 @@
         @foreach ($prefecture->questions as $question)
             <section class="">
                 <h4 class="outline d-inline">{{ $loop->iteration }}.この地名はなんて読む？</h4>
-                <img src="/images/{{ $question->image }}" alt="画像{{ $loop->iteration }}" class="">
+                {{-- <img src="/images/{{ $question->image }}" alt="画像{{ $loop->iteration }}" class=""> --}}
+                <img src="{{ asset('storage/temp/' . $question->image) }}" alt="画像{{ $loop->iteration }}">
                 <ul class="lists-arrange">
                     {{-- 参考：https://readouble.com/laravel/6.x/ja/collections.html --}}
                     {{-- shuffleメソッド・・コレクションのアイテムをランダムにシャッフル。 --}}

--- a/posse-3rd-laravel-study/routes/web.php
+++ b/posse-3rd-laravel-study/routes/web.php
@@ -43,3 +43,12 @@ Route::prefix('edit_question')->group(function () {
     Route::post('/update/{id}', 'AdminquestionController@update')->name('edit_question.update');
     Route::post('/destroy/{id}', 'AdminquestionController@destroy')->name('edit_question.destroy');
 });
+
+// 選択肢管理
+Route::prefix('edit_choice')->group(function () {
+    Route::get('/{question_id}', 'AdminchoiceController@index')->name('edit_choice.index');
+    Route::post('/{question_id}', 'AdminchoiceController@store')->name('edit_choice.store');
+    Route::get('/edit/{id}', 'AdminchoiceController@edit')->name('edit_choice.edit');
+    Route::post('/update/{id}', 'AdminchoiceController@update')->name('edit_choice.update');
+    Route::post('/destroy/{id}', 'AdminchoiceController@destroy')->name('edit_choice.destroy');
+});

--- a/posse-3rd-laravel-study/routes/web.php
+++ b/posse-3rd-laravel-study/routes/web.php
@@ -24,11 +24,22 @@ Route::get('/', 'QuizyController@index')->name('index');
 Route::get('/quiz/{id}', 'QuizyController@page')->name('page');
 
 // 管理画面
+// タイトル管理
 Route::prefix('edit_title')->group(function () {
-Route::get('/', 'AdmintitleController@index')->name('edit_title.index');
-Route::post('/', 'AdmintitleController@store')->name('edit_title.store');
-// 編集ルーティング
-Route::get('/edit/{id}','AdmintitleController@edit')->name('edit_title.edit');
-Route::post('/update/{id}','AdmintitleController@update')->name('edit_title.update');
-Route::post('/destroy/{id}','AdmintitleController@destroy')->name('edit_title.destroy');
+    Route::get('/', 'AdmintitleController@index')->name('edit_title.index');
+    Route::post('/', 'AdmintitleController@store')->name('edit_title.store');
+    // 編集ルーティング
+    Route::get('/edit/{id}', 'AdmintitleController@edit')->name('edit_title.edit');
+    Route::post('/update/{id}', 'AdmintitleController@update')->name('edit_title.update');
+    Route::post('/destroy/{id}', 'AdmintitleController@destroy')->name('edit_title.destroy');
+});
+
+// 設問管理
+Route::prefix('edit_question')->group(function () {
+    Route::get('/{id}', 'AdminquestionController@index')->name('edit_question.index');
+    Route::post('/{id}', 'AdminquestionController@store')->name('edit_question.store');
+    // 編集ルーティング
+    Route::get('/edit/{id}', 'AdminquestionController@edit')->name('edit_question.edit');
+    Route::post('/update/{id}', 'AdminquestionController@update')->name('edit_question.update');
+    Route::post('/destroy/{id}', 'AdminquestionController@destroy')->name('edit_question.destroy');
 });


### PR DESCRIPTION
# 今週の課題（43週目？）
カリキュラムシートに項目がなかったので自分で設定しました。
- [x] 登録済みの設問が一覧で表示される
- [x] 設問の追加
- [x] 設問の編集
- [x] 設問の削除
# 今週の課題（44週目）
- [x] 登録済みの選択肢が一覧で表示されていますか？
- [x] 登録済みの選択肢を変更可能ですか？
## 注意点やレビュワーに伝えたいこと(あれば)
画像押すと画像に応じた選択肢の管理ページに遷移します。

## 課題が終わっている証跡(スクショ)
43週目
![image](https://user-images.githubusercontent.com/86698414/178670406-bb75cbc1-bf0d-4405-b225-55465b6777ee.png)

44週目
![image](https://user-images.githubusercontent.com/86698414/178670252-42588b9e-3291-4503-a459-5c8bf05fb55d.png)
